### PR TITLE
Fix commas in prices, add gitignore and requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.venv/
+*.pyc
+.idea/

--- a/PriceSource.py
+++ b/PriceSource.py
@@ -294,7 +294,7 @@ class CryptoAssetCharts(PriceSource):
                 base_symbol = price_str_comp[1]
                 self._base_symbols.add(base_symbol)
             
-                price_val = locale.atof(price_str_comp[0])
+                price_val = locale.atof(price_str_comp[0].replace(',', ''))
                 self._price_map["_"+asset_symbol+"/"+base_symbol] = price_val
         
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask==0.10.1
+Flask-Cors==2.1.2
+networkx==1.11
+pyquery==1.2.11
+requests==2.9.1
+slackbot==0.3.0


### PR DESCRIPTION
locale.atof was failing (on my Mac) on values like "40,500.00".

gitignore is just for my convenience; i put my virtualenv in the directory.

requirements.txt added so now you can just say "pip install -Ur requirements.txt"
